### PR TITLE
[ISSUE]: #29 Create contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guidelines
+
+Thanks for taking the time to contribute! Contributors are what make Climb Beta great and we are happy to have you here.
+
+
+## Before You Begin
+Please, read over our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](code-of-conduct.md).
+
+## Where We Need Help
+View our [issues](https://github.com/chandojo/climbbeta/issues) to see where you can help. Choose an issue that you feel comfortable working on. When working on your selected issue, be sure to create a new feature/issue branch and fork the Climb Beta repository.
+
+## Pull Request Checklist
+Working on an issue and ready to send a pull request? Go through this checklist to make sure it fits our guidelines.
+
+1. Read [Contributing Guidelines](CONTRIBUTING.md)
+2. Read [Code of Conduct](code-of-conduct.md)
+3. Rebase your changes. *Make sure your local repository is updated with the most recent code from the Climb Beta Repository.*
+4. Include tests where applicable
+5. Run app Unit Tests (including your own)
+6. Submit pull Request. *Follow our [pull request format](#pull-request-format)*.
+
+### Pull Request Format
+Title | Description |
+-------|------------
+*Issue Number and Title* | * **Problem**: Problem the pull request addresses **Solution**: What the pull request does to fix this problem **Notes**: Any additional notes that are necessary*
+
+## Reporting Bugs
+ - Found a bug? Make sure it is not already reported in [issues](https://github.com/chandojo/climbbeta/issues)
+ - If not, [open a new issue](https://github.com/chandojo/climbbeta/issues/new). Including the following:
+  - **Short and descriptive title**
+  - **Clear description of the issue**
+  - **As much relevant information as possible.** Try not to leave others looking for more information.
+  - **Code Sample or Test Case** to show an expected behavior that is not occurring.
+
+## Feature Request
+ Have an idea that could make Climb Beta better and more useful? When submitting a feature request make sure to do the following:
+  - Take a moment to think if your idea fits the scope and aim of Climb Beta.
+  - Make a strong case for your idea.  Provide information about how and why your feature needs to be included in Climb Beta.
+  - Provide as much details and context as you can.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+


### PR DESCRIPTION
[PROBLEM]: Contributing documentation needed to guide future contributors

[SOLUTION]: Contributing.md and code-of-conduct.md created to assist and guide contributors

[NOTES]: Future editing of docs may be necessary with continuing contributions and changes that may arise.